### PR TITLE
Fix hierarchy walk for attribute property setters and add covariant test

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1573,10 +1573,7 @@ namespace System.Reflection
                                 }
                             }
 
-                            RuntimeMethodInfo? setMethod = null;
-                            RuntimeMethodInfo? getMethod = null;
                             Type baseAttributeType = attributeType;
-
                             for (; ; )
                             {
                                 RuntimePropertyInfo? property = (RuntimePropertyInfo?)(type is null ?
@@ -1585,9 +1582,7 @@ namespace System.Reflection
 
                                 if (property is not null)
                                 {
-                                    setMethod = property.GetSetMethod(true);
-                                    getMethod = property.GetGetMethod(true);
-
+                                    RuntimeMethodInfo? setMethod = property.GetSetMethod(true);
                                     if (setMethod is not null)
                                     {
                                         // Public properties may have non-public setter methods
@@ -1599,13 +1594,8 @@ namespace System.Reflection
                                         break;
                                     }
                                 }
-                                else
-                                {
-                                    setMethod = null;
-                                    getMethod = null;
-                                }
 
-                                baseAttributeType = baseAttributeType.BaseType is null || (getMethod is not null && !getMethod.IsVirtual)
+                                baseAttributeType = baseAttributeType.BaseType is null
                                     ? throw new CustomAttributeFormatException(SR.Format(SR.RFLCT_InvalidPropFail, name))
                                     : baseAttributeType.BaseType;
                             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
@@ -103,19 +103,13 @@ namespace Internal.Reflection.Extensions.NonPortable
                 }
                 else
                 {
-                    // Property
-                    MethodInfo? getMethod = null;
-                    MethodInfo? setMethod = null;
-
                     for (; ; )
                     {
                         PropertyInfo? propertyInfo = walk.GetProperty(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
 
                         if (propertyInfo is not null)
                         {
-                            getMethod = propertyInfo.GetGetMethod(true);
-                            setMethod = propertyInfo.GetSetMethod(true);
-
+                            MethodInfo? setMethod = propertyInfo.GetSetMethod(true);
                             if (setMethod is not null)
                             {
                                 // Public properties may have non-public setter methods
@@ -127,16 +121,10 @@ namespace Internal.Reflection.Extensions.NonPortable
                                 break;
                             }
                         }
-                        else
-                        {
-                            getMethod = null;
-                            setMethod = null;
-                        }
 
-                        Type? baseType = walk.BaseType;
-                        if (baseType == null || (getMethod is not null && !getMethod.IsVirtual))
-                            throw new CustomAttributeFormatException(SR.Format(SR.RFLCT_InvalidPropFail, name));
-                        walk = baseType;
+                        walk = walk.BaseType is null
+                            ? throw new CustomAttributeFormatException(SR.Format(SR.RFLCT_InvalidPropFail, name))
+                            : walk.BaseType;
                     }
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
@@ -240,7 +240,6 @@ namespace ILCompiler.DependencyAnalysis
 
             MetadataReader reader = attributeTypeDefinition.MetadataReader;
             var typeDefinition = reader.GetTypeDefinition(attributeTypeDefinition.Handle);
-            MethodDesc getterMethod = null;
 
             foreach (PropertyDefinitionHandle propDefHandle in typeDefinition.GetProperties())
             {
@@ -262,21 +261,18 @@ namespace ILCompiler.DependencyAnalysis
                         }
 
                         dependencies.Add(factory.ReflectedMethod(setterMethod.GetCanonMethodTarget(CanonicalFormKind.Specific)), "Custom attribute blob");
+                        return true;
                     }
 
-                    if (!accessors.Getter.IsNil)
-                    {
-                        getterMethod = (MethodDesc)attributeTypeDefinition.EcmaModule.GetObject(accessors.Getter);
-                    }
-
-                    return true;
+                    // Property found without a setter - check base type
+                    break;
                 }
             }
 
             // Haven't found it in current type. Check the base type.
             TypeDesc baseType = attributeType.BaseType;
 
-            if (baseType != null && (getterMethod is null || getterMethod.IsVirtual))
+            if (baseType != null)
                 return AddDependenciesFromPropertySetter(dependencies, factory, baseType, propertyName);
 
             // Not found. This is bad metadata that will result in a runtime failure, but we shouldn't fail the compilation.

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Attributes.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Attributes.cs
@@ -325,6 +325,12 @@ namespace System.Tests
             Assert.Equal(2, derivedAttributeWithGetterAttr.P);
         }
 
+        [Fact]
+        public static void GetCustomAttributesWithCovariantOverrideAndSetterOnBaseClass_Throws()
+        {
+            Assert.Throws<CustomAttributeFormatException>(() => typeof(ClassWithDerivedCovariantAttr).GetCustomAttributes(true));
+        }
+
         private static void GenericAttributesTestHelper<TGenericParameter>(Func<Type, Attribute[]> getCustomAttributes)
         {
             Attribute[] openGenericAttributes = getCustomAttributes(typeof(GenericAttribute<>));
@@ -360,6 +366,20 @@ namespace System.Tests
 
         [DerivedAttributeWithGetter(P = 2)]
         public class ClassWithDerivedAttr
+        { }
+
+        public class BaseAttributeWithObjectProp : Attribute
+        {
+            public virtual object Prop { get; set; }
+        }
+
+        public class DerivedAttributeWithCovariantGetter : BaseAttributeWithObjectProp
+        {
+            public override string Prop { get => (string)base.Prop; }
+        }
+
+        [DerivedAttributeWithCovariantGetter(Prop = "hello")]
+        public class ClassWithDerivedCovariantAttr
         { }
     }
 

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -1248,9 +1248,8 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 			MonoProperty *prop = NULL;
 			MonoProperty *firstNotNullPropInHierarchy = NULL;
 			MonoMethod *setMethod = NULL;
-			MonoMethod *getMethod = NULL;
 			MonoClass *attrBaseClass = mono_handle_class (attr);
-			while (!setMethod && attrBaseClass && (!prop || !getMethod || m_method_is_virtual(getMethod)))
+			while (!setMethod && attrBaseClass)
 			{
 				prop = mono_class_get_property_from_name_internal (attrBaseClass, name);
 
@@ -1262,12 +1261,6 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 					}
 
 					setMethod = prop->set;
-					getMethod = prop->get;
-				}
-				else
-				{
-					setMethod = NULL;
-					getMethod = NULL;
 				}
 
 				attrBaseClass = m_class_get_parent(attrBaseClass);


### PR DESCRIPTION
- Fix Mono: remove !prop from while condition that caused early exit when property was found on derived type without setter
- Fix ILCompiler: only return true when setter is found, break to base type check when property has no setter
- Simplify CoreCLR/NativeAOT: remove unnecessary getMethod tracking and unconditionally walk hierarchy when no setter found
- Add test for covariant return type override (issue #119490) that verifies CustomAttributeFormatException is thrown